### PR TITLE
Add NPY_NO_DEPRECATED_API to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
         
         ext_modules=[Extension("gravhopper._jbgrav", ["gravhopper/_jbgrav.c"])],
         include_dirs=numpy.get_include(),
+        define_macros=[("NPY_NO_DEPRECATED_API", "NPY_2_0_API_VERSION")]
         )
 


### PR DESCRIPTION
I started using gravhopper a few years ago as an undergraduate and have been a big fan since, having used it for numerous purposes. Recently, I attempted to install gravhopper in a new environment and received the following error: 

> A module that was compiled using NumPy 1.x cannot be run in
> NumPy 2.2.1 as it may crash. To support both 1.x and 2.x
> versions of NumPy, modules must be compiled with NumPy 2.0.
> Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.
> 
> If you are a user of the module, the easiest solution will be to
> downgrade to 'numpy<2' or try to upgrade the affected module.
> We expect that some modules will need time to support NumPy 2.

I applied a simple fix in the `setup.py` file which seems to work well on my end. I wanted to do what I can to keep this great package in the community tool box! I hope this helps :)